### PR TITLE
Normalised temp directory based on the OS

### DIFF
--- a/tests/test_png.py
+++ b/tests/test_png.py
@@ -1,16 +1,20 @@
 import cv2
 import numpy as np
+import tempfile as tf
 
 image = (np.random.rand(256, 256) * 255).astype('uint16')
-cv2.imwrite('/tmp/a.png', image)
-image2 = cv2.imread('/tmp/a.png', -1)
+tmp = tf.NamedTemporaryFile(suffix='.png', prefix='a')
+tmp.close()
+print(tf.gettempdir())
+cv2.imwrite(tmp.name, image)
+image2 = cv2.imread(tmp.name, -1)
 (image == image2).all()
 print(type(image[0][0]))
 print(type(image2[0][0]))
 
 image = (np.random.rand(256, 256) * 255).astype('int16')
-cv2.imwrite('/tmp/a.png', image)
-image2 = cv2.imread('/tmp/a.png',-1)
+cv2.imwrite(tmp.name, image)
+image2 = cv2.imread(tmp.name, -1)
 (image == image2).all()
 print(type(image[0][0]))
 print(type(image2[0][0]))


### PR DESCRIPTION
Response to [issue #92 ](https://github.com/Sistemas-Multimedia/MCDWT/issues/92).

The test now create a temporary file in the /tmp directory based on the OS. Tested on Linux and Windows.