### PR TITLE
Fix issue #85 in motion.py

### DIFF
--- a/mcdwt/motion.py
+++ b/mcdwt/motion.py
@@ -19,5 +19,4 @@ def estimate_frame(base, flow):
     map_xy = (flow + np.dstack((map_x, map_y))).astype('float32')
 
     return cv2.remap(base, map_xy, None, 
-            interpolation=cv2.INTER_LINEAR, 
-            borderMode=cv2.BORDER_TRANSPARENT)
+            interpolation=cv2.INTER_LINEAR)


### PR DESCRIPTION
Removed BORDER_TRANSPARENT extrapolation of non-existing pixels.