### PR TITLE
Changed remap border criteria to BORDER_REPLICATE.

### DIFF
--- a/mcdwt/motion.py
+++ b/mcdwt/motion.py
@@ -19,4 +19,5 @@ def estimate_frame(base, flow):
     map_xy = (flow + np.dstack((map_x, map_y))).astype('float32')
 
     return cv2.remap(base, map_xy, None, 
-            interpolation=cv2.INTER_LINEAR)
+            interpolation=cv2.INTER_LINEAR,
+            borderMode=cv2.BORDER_REPLICATE)

--- a/tests/temporal_interpolation.py
+++ b/tests/temporal_interpolation.py
@@ -15,7 +15,7 @@ output_path = tf.gettempdir()
 
 frames = []
 for i in range(n):
-    path = os.path.join(input_path, 'r_{:03d}.png'.format(i))
+    path = os.path.join(input_path, '{:03d}.png'.format(i))
     print('Reading frame:', path)
     frames.append(cv2.imread(path))
 

--- a/tests/temporal_interpolation.py
+++ b/tests/temporal_interpolation.py
@@ -15,7 +15,7 @@ output_path = tf.gettempdir()
 
 frames = []
 for i in range(n):
-    path = os.path.join(input_path, '{:03d}.png'.format(i))
+    path = os.path.join(input_path, 'r_{:03d}.png'.format(i))
     print('Reading frame:', path)
     frames.append(cv2.imread(path))
 


### PR DESCRIPTION
This PR changes the border criteria of `remap` from `BORDER_CONSTANT` to `BORDER_REPLICATE` to remove the black pixels generated in some cases of `temporal_interpolation.py`. 

Part of issue #98. 